### PR TITLE
The unexpected trigger of the error trap fix.

### DIFF
--- a/vivaldi-autoinject-custom-js-ui
+++ b/vivaldi-autoinject-custom-js-ui
@@ -163,7 +163,9 @@ installhook() {
 
 local hookpath=$_prefix/share/libalpm/hooks/vivaldi-UI-js.hook
 
-[[ -d ${hookpath%/*} && ! -f $hookpath ]] || return
+if [[ -d ${hookpath%/*} && -f $hookpath ]]; then
+   return
+fi
 
 cat << EOB > "$hookpath"
 [Trigger]


### PR DESCRIPTION
The script allways exited with an error status because the hook presence check triggered the error trap. I've fixed that by changing the way the check is performed.